### PR TITLE
Removed cache check

### DIFF
--- a/src/ueye_cam_nodelet.cpp
+++ b/src/ueye_cam_nodelet.cpp
@@ -228,8 +228,6 @@ bool UEyeCamNodelet::exposureCallback(ueye_cam::SetExposure::Request& req,
                                       ueye_cam::SetExposure::Response& _) {
     double exposure_ms = double(req.exposure_ms);
 
-    if (cam_params_.exposure - exposure_ms < 0.0001) return true;
-
     bool auto_exposure = cam_params_.auto_exposure;
     double auto_exposure_ref = cam_params_.auto_exposure_reference;
 


### PR DESCRIPTION
With the check in place, the second update always return without any change, even if the previous exposure is different to the new one.
Should be investigated further before putting it back.